### PR TITLE
Add Memento support

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,4 +1,6 @@
 julia 0.6
+Compat 0.26
 DataStreams 0.3.1
 DocStringExtensions
 Missings 0.2.1
+Memento 0.3

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -7,6 +7,8 @@ using NamedTuples
 using Missings
 
 
+Memento.config("critical")
+
 @testset ExtendedTestSet "LibPQ" begin
 
 @testset "ConninfoDisplay" begin


### PR DESCRIPTION
Log all messages via Memento (which now defaults to `warn`) to allow more verbose messages at lower levels in the future. Once [this](https://github.com/invenia/Memento.jl/pull/36) is tagged, there will be no log output in a successful test run.

Also got rid of the non-precompilable `global const` in `__init__`. 

Close #12 