### PR TITLE
fix missing module qualifier for JLConnectionError

### DIFF
--- a/src/connections.jl
+++ b/src/connections.jl
@@ -738,7 +738,7 @@ function conninfo(str::AbstractString)
     ci_ptr = libpq_c.PQconninfoParse(str, err_ref)
 
     if ci_ptr == C_NULL && err_ref[] == C_NULL
-        error(LOGGER, JLConnectionError(
+        error(LOGGER, Errors.JLConnectionError(
             "libpq could not allocate memory for connection info"
         ))
     end


### PR DESCRIPTION
Fixes a typo qualifying JLConnectionError. Difficult to hit condition, but could result in `UndefVarError: JLConnectionError`.