### PR TITLE
Ensure `string_params` doesn't get GC'd

### DIFF
--- a/src/asyncresults.jl
+++ b/src/asyncresults.jl
@@ -252,7 +252,9 @@ function async_execute(
     pointer_params = parameter_pointers(string_params)
 
     async_result = _async_execute(jl_conn; binary_format=binary_format, kwargs...) do jl_conn
-            GC.@preserve string_params _async_submit(jl_conn.conn, query, pointer_params; binary_format=binary_format)
+            GC.@preserve string_params _async_submit(
+                jl_conn.conn, query, pointer_params; binary_format=binary_format
+            )
         end
 
     return async_result

--- a/src/asyncresults.jl
+++ b/src/asyncresults.jl
@@ -249,9 +249,9 @@ function async_execute(
     kwargs...,
 )
     string_params = string_parameters(parameters)
-    pointer_params = parameter_pointers(string_params)
-
+    
     async_result = _async_execute(jl_conn; binary_format=binary_format, kwargs...) do jl_conn
+            pointer_params = parameter_pointers(string_params)
             _async_submit(jl_conn.conn, query, pointer_params; binary_format=binary_format)
         end
 

--- a/src/asyncresults.jl
+++ b/src/asyncresults.jl
@@ -250,7 +250,7 @@ function async_execute(
 )
     string_params = string_parameters(parameters)
     pointer_params = parameter_pointers(string_params)
-    
+
     async_result = _async_execute(jl_conn; binary_format=binary_format, kwargs...) do jl_conn
             GC.@preserve string_params _async_submit(jl_conn.conn, query, pointer_params; binary_format=binary_format)
         end

--- a/src/asyncresults.jl
+++ b/src/asyncresults.jl
@@ -249,10 +249,10 @@ function async_execute(
     kwargs...,
 )
     string_params = string_parameters(parameters)
+    pointer_params = parameter_pointers(string_params)
     
     async_result = _async_execute(jl_conn; binary_format=binary_format, kwargs...) do jl_conn
-            pointer_params = parameter_pointers(string_params)
-            _async_submit(jl_conn.conn, query, pointer_params; binary_format=binary_format)
+            GC.@preserve string_params _async_submit(jl_conn.conn, query, pointer_params; binary_format=binary_format)
         end
 
     return async_result

--- a/src/copy.jl
+++ b/src/copy.jl
@@ -52,7 +52,7 @@ function execute(
         if parameters === nothing
             result = _execute(jl_conn.conn, copy.query)
         else
-            result = _execute(jl_conn.conn, copy.query, pointer_params)
+            GC.@preserve string_params result = _execute(jl_conn.conn, copy.query, pointer_params)
         end
         result_status = libpq_c.PQresultStatus(result)
 

--- a/src/copy.jl
+++ b/src/copy.jl
@@ -52,7 +52,9 @@ function execute(
         if parameters === nothing
             result = _execute(jl_conn.conn, copy.query)
         else
-            GC.@preserve string_params result = _execute(jl_conn.conn, copy.query, pointer_params)
+            result = GC.@preserve string_params _execute(
+                jl_conn.conn, copy.query, pointer_params
+            )
         end
         result_status = libpq_c.PQresultStatus(result)
 

--- a/src/results.jl
+++ b/src/results.jl
@@ -322,7 +322,9 @@ function execute(
     pointer_params = parameter_pointers(string_params)
 
     result = lock(jl_conn) do
-        GC.@preserve string_params _execute(jl_conn.conn, query, pointer_params; binary_format=binary_format)
+        GC.@preserve string_params _execute(
+            jl_conn.conn, query, pointer_params; binary_format=binary_format
+        )
     end
 
     return handle_result(

--- a/src/results.jl
+++ b/src/results.jl
@@ -322,7 +322,7 @@ function execute(
     pointer_params = parameter_pointers(string_params)
 
     result = lock(jl_conn) do
-        _execute(jl_conn.conn, query, pointer_params; binary_format=binary_format)
+        GC.@preserve string_params _execute(jl_conn.conn, query, pointer_params; binary_format=binary_format)
     end
 
     return handle_result(

--- a/src/statements.jl
+++ b/src/statements.jl
@@ -121,7 +121,7 @@ function execute(
     pointer_params = parameter_pointers(string_params)
 
     result = lock(stmt.jl_conn) do
-        _execute_prepared(
+        GC.@preserve string_params _execute_prepared(
             stmt.jl_conn.conn, stmt.name, pointer_params; binary_format=binary_format
         )
     end


### PR DESCRIPTION
# Solution summary

In `parameter_pointers` we create a new vector with pointers to elements of the `string_params`.
As `string_params` isn't referenced later in the `do ... end` block there's a chance it can get swiped by GC mid run and make the pointers point at garbage.
We can protect `string_params` using `GC.@preserve` for the duration of the ccall

We can do something else to get the same behavior if needed, but the goal is to protect `string_params` from GC.

# How did we find this

## Error

I observed it when benchmarking an endpoint that had a pretty heavy db query behind it.
The error basically means we tried to parse garbage in the response.
The first column in the query was a `bigint`, so the theory that there's garbage in the LibPQ result buffer checked out

```julia
nested task error: InvalidTextRepresentation: ERROR:  invalid input syntax for type bigint: "\g<1>"
Stacktrace:
 [1] handle_result(async_result::LibPQ.AsyncResult{false}; throw_error::Bool)
   @ LibPQ ~/depot/packages/LibPQ/gYEIG/src/asyncresults.jl:74
 [2] handle_result
   @ ~/depot/packages/LibPQ/gYEIG/src/asyncresults.jl:55 [inlined]
 [3] (::LibPQ.var"#105#107"{Bool, LibPQ.var"#101#102"{Bool, String, Vector{Ptr{UInt8}}}, LibPQ.Connection, LibPQ.AsyncResult{false}})()
   @ LibPQ ~/depot/packages/LibPQ/gYEIG/src/asyncresults.jl:280
 [4] lock(f::LibPQ.var"#105#107"{Bool, LibPQ.var"#101#102"{Bool, String, Vector{Ptr{UInt8}}}, LibPQ.Connection, LibPQ.AsyncResult{false}}, conn::LibPQ.Connection)
   @ LibPQ ~/depot/packages/LibPQ/gYEIG/src/connections.jl:337
 [5] (::LibPQ.var"#104#106"{Bool, LibPQ.var"#101#102"{Bool, String, Vector{Ptr{UInt8}}}, LibPQ.Connection, LibPQ.AsyncResult{false}})()
   @ LibPQ ./task.jl:514
```

## Debugging

There's no reproducer outside of the original process in which this was observed, but in that process it is very easily reproducible.

Seems like there needs to be a lucky combination of a pretty fast cpu, some other async clutter in the process, the query needs to be heavy and there needs to be some postprocessing to trigger GC (in our case `@time` on the db query would report 30% GC time)

After heavy investigation I managed to filter the potential suspect list and came up with 3 observations:

1. Julia wise everything seemed correct. We use a connection pool and after swapping it for a different implementation the issue persisted. Connection management itself was in line with what LibPQ required to operate properly 
2. Removing post-processing made the issue go away (now I know it's because GC would not be that active in the timeframe)
3. Removing query parameters made the issue go away (which was kinda weird)

## Solution

@tanmaykm looked at the above observations and looked into the query parameters implementation, which turned out not to be 100% GC safe and proposed the solution

I verified it and I can no longer reproduce the issue. There's no visible performance penalty in my testing and I've also noticed I can no longer see these weird cases where the response length would be different sometimes (which may have been cases where this didn't error, but passed normally)

