### PR TITLE
update doc on multiple `async_execute` behavior

### DIFF
--- a/src/asyncresults.jl
+++ b/src/asyncresults.jl
@@ -201,7 +201,8 @@ All keyword arguments are the same as [`execute`](@ref) and are passed to the cr
 `Result`.
 
 Only one `AsyncResult` can be active on a [`Connection`](@ref) at once.
-If multiple `AsyncResult`s use the same `Connection`, they will execute serially.
+If multiple `AsyncResult`s use the same `Connection`, they will execute serially but
+without any guarantee of order.
 
 `async_execute` does not yet support [`Statement`](@ref)s.
 


### PR DESCRIPTION
From what it appears, the order of execution when multiple `async_execute` operations are invoked with the same `Connection` is probably not guaranteed. It relies on the task schedule and locking behavior [here](https://github.com/iamed2/LibPQ.jl/blob/2c0547daef005e160aa60cb529d4969a670befbc/src/asyncresults.jl#L270).

It probably needs non trivial changes to guarantee an order there. Until then it will be good to update the docs with this fact.